### PR TITLE
players who didnt get their bet dont bonus points, so set bonus to 0

### DIFF
--- a/scripts/scoreCard/generateRoundForm/generatePlayerInputs.js
+++ b/scripts/scoreCard/generateRoundForm/generatePlayerInputs.js
@@ -6,6 +6,17 @@ const { getCurrentPlayers } = playersTracker();
 const { getCurrentStep } = stepTracker();
 const { lookUpRound } = scoreTracker();
 
+const setBonusToZero = (player) => {
+  const bonusInput = document.getElementById(
+    `${player}-Bonus_${getCurrentStep()}`
+  );
+
+  // if a value is already set don't override it
+  if (!bonusInput.value) {
+    bonusInput.value = "0";
+  }
+};
+
 const generatePlayerInputs = () => {
   let inputs = new DocumentFragment();
 
@@ -45,14 +56,18 @@ const generatePlayerInputs = () => {
         input.addEventListener("blur", (event) => {
           // the majority of the time when a player bids zero they can not earn any bonus points
           if (event.target.value === "0") {
-            const bonusInput = document.getElementById(
-              `${player}-Bonus_${getCurrentStep()}`
-            );
-
-            // if a value is already set don't override it
-            if (!bonusInput.value) {
-              bonusInput.value = "0";
-            }
+            setBonusToZero(player);
+          }
+        });
+      }
+      if (type === "Won") {
+        input.addEventListener("blur", (event) => {
+          const wantedValue = document.getElementById(
+            `${player}-Wanted_${getCurrentStep()}`
+          ).value;
+          // players who didn't get their bet don't bonus points, so set bonus to 0
+          if (wantedValue != event.target.value && event.target.value > 0) {
+            setBonusToZero(player);
           }
         });
       }

--- a/scripts/scoreCard/generateRoundForm/generatePlayerInputs.js
+++ b/scripts/scoreCard/generateRoundForm/generatePlayerInputs.js
@@ -65,8 +65,8 @@ const generatePlayerInputs = () => {
           const wantedValue = document.getElementById(
             `${player}-Wanted_${getCurrentStep()}`
           ).value;
-          // players who didn't get their bet don't bonus points, so set bonus to 0
-          if (wantedValue != event.target.value && event.target.value > 0) {
+          // players who didn't get their bid don't get bonus points. So set bonus points to 0.
+          if (wantedValue !== event.target.value && event.target.value > 0) {
             setBonusToZero(player);
           }
         });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47189980/103447161-b39f9800-4c44-11eb-9b90-4ad54e020b0c.png)
Great website! We use it every time we play skull king. My Pull Request is just a QOL change. Basically, if a player doesn't get their bet, they don't get bonus points, so I have it set bonus pints to 0 automatically. If you need me to change anything let me know! My email is zacharykirby11@gmail.com. Thank! 